### PR TITLE
Avoid using boolean values for the python class

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -15,9 +15,9 @@ class graphiteapi::install {
   # @TODO: Decouple this a bit if possible.
   if (!defined(Class['python'])) {
     class { 'python':
-      dev        => true,
-      pip        => true,
-      virtualenv => true,
+      dev        => 'present',
+      pip        => 'present',
+      virtualenv => 'present',
     }
   }
 


### PR DESCRIPTION
https://github.com/stankevich/puppet-python deprecated boolean values for class parameters a while back causing warnings in puppetserver log files.
